### PR TITLE
增加了半角片假名替换，去掉了词典中的扩展区汉字条目，把「𠮟」替换成了「叱」

### DIFF
--- a/ja_JP.aff
+++ b/ja_JP.aff
@@ -3,6 +3,89 @@ LANG ja
 FLAG long
 # https://github.com/MrCorn0-0/hunspell_ja_JP/
 
+ICONV 81
+ICONV ｶﾞ ガ
+ICONV ｷﾞ ギ
+ICONV ｸﾞ グ
+ICONV ｹﾞ ゲ
+ICONV ｺﾞ ゴ
+ICONV ｻﾞ ザ
+ICONV ｼﾞ ジ
+ICONV ｽﾞ ズ
+ICONV ｾﾞ ゼ
+ICONV ｿﾞ ゾ
+ICONV ﾀﾞ ダ
+ICONV ﾁﾞ ヂ
+ICONV ﾂﾞ ヅ
+ICONV ﾃﾞ デ
+ICONV ﾄﾞ ド
+ICONV ﾊﾞ バ
+ICONV ﾋﾞ ビ
+ICONV ﾌﾞ ブ
+ICONV ﾍﾞ ベ
+ICONV ﾎﾞ ボ
+ICONV ﾊﾟ パ
+ICONV ﾋﾟ ピ
+ICONV ﾌﾟ プ
+ICONV ﾍﾟ ペ
+ICONV ﾎﾟ ポ
+ICONV ｱ ア
+ICONV ｲ イ
+ICONV ｳ ウ
+ICONV ｴ エ
+ICONV ｵ オ
+ICONV ｶ カ
+ICONV ｷ キ
+ICONV ｸ ク
+ICONV ｹ ケ
+ICONV ｺ コ
+ICONV ｻ サ
+ICONV ｼ シ
+ICONV ｽ ス
+ICONV ｾ セ
+ICONV ｿ ソ
+ICONV ﾀ タ
+ICONV ﾁ チ
+ICONV ﾂ ツ
+ICONV ﾃ テ
+ICONV ﾄ ト
+ICONV ﾅ ナ
+ICONV ﾆ ニ
+ICONV ﾇ ヌ
+ICONV ﾈ ネ
+ICONV ﾉ ノ
+ICONV ﾊ ハ
+ICONV ﾋ ヒ
+ICONV ﾌ フ
+ICONV ﾍ ヘ
+ICONV ﾎ ホ
+ICONV ﾏ マ
+ICONV ﾐ ミ
+ICONV ﾑ ム
+ICONV ﾒ メ
+ICONV ﾓ モ
+ICONV ﾔ ヤ
+ICONV ﾕ ユ
+ICONV ﾖ ヨ
+ICONV ﾗ ラ
+ICONV ﾘ リ
+ICONV ﾙ ル
+ICONV ﾚ レ
+ICONV ﾛ ロ
+ICONV ﾜ ワ
+ICONV ｦ ヲ
+ICONV ﾝ ン
+ICONV ｧ ァ
+ICONV ｨ ィ
+ICONV ｩ ゥ
+ICONV ｪ ェ
+ICONV ｫ ォ
+ICONV ｯ ッ
+ICONV ｬ ャ
+ICONV ｭ ュ
+ICONV ｮ ョ
+ICONV ｰ ー
+
 #拼写变体
 MAP	89
 MAP	あア


### PR DESCRIPTION
老版本的GoldenDict 1.5.0的hunspell处理非BMP的汉字会崩溃。一些比较新的MDX词典会使用「𠮟」，不过这些词典用「叱」也能搜到。老的EPWING词典都是「叱」。

インターネット上で”しかる”を漢字で表現するには、ほとんどの場合JIS規格にもともと含まれている “叱”が使われてきた。2004年の新JIS規格で”𠮟”が追加されても、それは第3水準に含まれており、 Shift-JISのほとんどの実装では対応しておらず、実質使うことができなかった。https://hydrocul.github.io/wiki/blog/2014/1201-shikaru.html